### PR TITLE
Use dtype=theano.config.floatX in binomial calls

### DIFF
--- a/model.py
+++ b/model.py
@@ -339,9 +339,9 @@ class ConvModel:
                     rng.randint(9999))
 
             prev_output = slices
-            prev_output = prev_output * srng.binomial(n=1,
-                p=1-dropout_p, size=prev_output.shape) / ((1-dropout_p)**0.5)
-
+            prev_output = prev_output * srng.binomial(
+                n=1, p=1-dropout_p, size=prev_output.shape,
+                dtype=theano.config.floatX) / ((1-dropout_p)**0.5)
             for i in range(depth):
                 layer = StrConvLayer(
                           input = prev_output,
@@ -359,13 +359,15 @@ class ConvModel:
                     )
                 dropout_layers.append(layer)
                 prev_output = layer.output
-                prev_output = prev_output * srng.binomial(n=1,
-                    p=1-dropout_p, size=prev_output.shape) / (1-dropout_p)
+                prev_output = prev_output * srng.binomial(
+                    n=1, p=1-dropout_p, size=prev_output.shape,
+                    dtype=theano.config.floatX) / (1-dropout_p)
                 softmax_inputs.append(T.sum(layer.output, axis=0)) # summing over columns
 
             softmax_input = T.concatenate(softmax_inputs, axis=1) / x.shape[0]
-            softmax_input = softmax_input * srng.binomial(n=1,
-                    p=1-dropout_p, size=softmax_input.shape) / ((1-dropout_p)**0.5)
+            softmax_input = softmax_input * srng.binomial(
+                n=1, p=1-dropout_p, size=softmax_input.shape,
+                dtype=theano.config.floatX) / ((1-dropout_p)**0.5)
 
             dropout_layers.append( SoftmaxLayer(
                     input = softmax_input,


### PR DESCRIPTION
Hello, thanks for sharing your code!  Here's a small fix to get it running on GPUs.

By default, `srng.binomial` will return shared variables with dtype int64. When you divide such a shared variable by a Python float built-in (such as the division by `1 - dropout_p`), the result gets cast to a float64, regardless of the value of `theano.config.floatX`, which causes problems on GPUs which require float32.  Setting `dtype=theano.config.floatX` in the calls will prevent this from happening.
